### PR TITLE
use Buffer instead of binary string for crypto.createCipheriv key

### DIFF
--- a/lib/ntlm.js
+++ b/lib/ntlm.js
@@ -208,8 +208,7 @@ function makeResponse(hash, nonce)
   var out = new Buffer(24);
   for (var i = 0; i < 3; i++) {
     var keybuf = $.oddpar($.expandkey(hash.slice(i * 7, i * 7 + 7)));
-    var key = keybuf.toString('binary');
-    var des = crypto.createCipheriv('DES-ECB', key, '');
+    var des = crypto.createCipheriv('DES-ECB', keybuf, '');
     var str = des.update(nonce.toString('binary'), 'binary', 'binary');
     out.write(str, i * 8, i * 8 + 8, 'binary');
   }

--- a/lib/smbhash.js
+++ b/lib/smbhash.js
@@ -43,8 +43,7 @@ function lmhashbuf(inputstr)
   var buf = new Buffer(16);
   var pos = 0;
   var cts = halves.forEach(function(z) {
-    var key = z.toString('binary');
-    var des = crypto.createCipheriv('DES-ECB', key, '');
+    var des = crypto.createCipheriv('DES-ECB', z, '');
     var str = des.update('KGS!@#$%', 'binary', 'binary');
     buf.write(str, pos, pos + 8, 'binary');
     pos += 8;


### PR DESCRIPTION
The default string encoding used by the crypto module changed in node v6.0.0 from binary to utf8. So binary string is being interpreted as utf8 and in many cases becoming larger than 16 bytes during that conversion process (rather than smaller than 16 bytes) due to invalid utf8 character bytes being added. Instead of converting to binary string, we can pass Buffer directly to avoid this.
